### PR TITLE
fix: no use of this in parseParams

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ const Koa66 = module.exports = class Koa66 {
                 if (!route.method) {
                     middlewares.push(route.middleware);
                     if (route.paramNames)
-                        ctx.params = this.parseParams(route.paramNames, ctx.path.match(route.regexp).slice(1))
+                        ctx.params = this.parseParams(ctx.params, route.paramNames, ctx.path.match(route.regexp).slice(1))
                     return;
                 }
 
@@ -94,7 +94,7 @@ const Koa66 = module.exports = class Koa66 {
                     matched = true;
                     middlewares.push(route.middleware);
                     if (route.paramNames)
-                        ctx.params = this.parseParams(route.paramNames, ctx.path.match(route.regexp).slice(1))
+                        ctx.params = this.parseParams(ctx.params, route.paramNames, ctx.path.match(route.regexp).slice(1))
                 }
             });
 
@@ -176,17 +176,17 @@ const Koa66 = module.exports = class Koa66 {
      * @return {[Object]}
      * @api private
      */
-    parseParams(paramNames, captures) {
+    parseParams(params, paramNames, captures) {
         const len = captures.length;
-        this.params = this.params || {};
+        params = params || {};
 
         for (let i = 0; i < len; i++) {
             if (paramNames[i]) {
                 let c = captures[i];
-                this.params[paramNames[i].name] = c ? decodeURIComponent(c) : c;
+                params[paramNames[i].name] = c ? decodeURIComponent(c) : c;
             }
         }
-        return this.params;
+        return params;
     };
 
 }


### PR DESCRIPTION
Currently the `parseParams` function writes all params into `this.params`.

When there are more than one requests at the same time, and one of them takes longer to respond, `this.params` and thus `ctx.params` will be overwritten.

To fix this problem, i avoided `this` in `parseParams` and passed `ctx.params` as an argument.

To show this problem i made a little [script](https://gist.github.com/alexanderneu/58087a873f785061cd8c) that uses `setTimeout` as a delay for requests.
