### PR TITLE
attach route to context

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,6 +129,9 @@ class Koa66 {
                 // path test
                 if (!route.regexp.test(ctx.path)) return;
 
+                // Save the route so we can access ctx.route.path
+                ctx.route = route;
+
                 if (route.paramNames)
                     ctx.params = this.parseParams(ctx.params, route.paramNames, ctx.path.match(route.regexp).slice(1))
 

--- a/test/index.js
+++ b/test/index.js
@@ -272,6 +272,30 @@ describe('Koa-66', () => {
                 .end(done);
         });
 
+        it('.mount should mount nested routes', done => {
+            const app = new Koa();
+            const rootRouter = new Router();
+            const apiRouter = new Router();
+            const router = new Router();
+
+            router.get('/:id', ctx => {
+              ctx.body = 'world';
+              ctx.route.path.should.be.equal('/api/v1/ticket/:id');
+            });
+
+            apiRouter.mount('/ticket', router);
+            rootRouter.mount('/api/v1', apiRouter);
+            let util = require('util');
+            //Must be the last
+            app.use(rootRouter.routes());
+
+            request(app.listen())
+                .get('/api/v1/ticket/66')
+                .expect(200)
+                .expect('world')
+                .end(done);
+        });
+
         it('.mount should 404 with old path', done => {
             const app = new Koa();
             const router = new Router();

--- a/test/index.js
+++ b/test/index.js
@@ -285,7 +285,6 @@ describe('Koa-66', () => {
 
             apiRouter.mount('/ticket', router);
             rootRouter.mount('/api/v1', apiRouter);
-            let util = require('util');
             //Must be the last
             app.use(rootRouter.routes());
 


### PR DESCRIPTION
This PR adds the matched `route` to the koa `context`. It allows to retrieve the route path (i.e `/tickets/:id`) in the route handler, this modification is needed in my use case to find out if the request is authorized.
