### PR TITLE
Call param() middleware before the first actual match.

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,6 +170,11 @@ class Koa66 {
                 if ((route.methods.indexOf(ctx.method) !== -1) ||
                     (ctx.method === 'HEAD' && route.methods.indexOf('GET') !== -1)) {
                     matched = true;
+                    for (let i in ctx.params) {
+                        if (paramMiddlewares[i])
+                            middlewares.push(paramMiddlewares[i]);
+                            delete paramMiddlewares[i]
+                    }
                     middlewares.push(route.middleware);
                 }
             });
@@ -202,13 +207,7 @@ class Koa66 {
                 return next();
             }
 
-            const _params = [];
-            for (let i in ctx.params) {
-                if (paramMiddlewares[i])
-                    _params.push(paramMiddlewares[i]);
-            }
-
-            return compose(_params.concat(middlewares))(ctx, next);
+            return compose(middlewares)(ctx, next);
         };
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -720,6 +720,36 @@ describe('Koa-66', () => {
                 })
                 .end(done);
         });
+
+        it('doesn\'t run parameter middleware if path matched does not have a parameter', done => {
+            const app = new Koa();
+            const router = new Router();
+            router.param('id', (ctx, next, id) => {
+                ctx.ranParam = 'true';
+                next();
+            });
+
+            router.get('/test', ctx => {
+                ctx.body = ctx.ranParam || 'false'
+            });
+            router.get('/:id', ctx => {
+                ctx.body = ctx.ranParam || 'false'
+            });
+            app.use(router.routes());
+
+            request(app.listen())
+            .get('/test')
+            .expect(200)
+            .expect('false')
+            .end((err) => {
+                if (err) return done(err);
+                request(app.listen())
+                .get('/not-test')
+                .expect(200)
+                .expect('true')
+                .end(done);
+            });
+        });
     });
 
     describe('plugins', () => {


### PR DESCRIPTION
Fix the param matching to behave exactly the same as `koa-router` or `express`.
Its useful for cases where you have routes with params on the same level as hardcoded ones.
e.g. 

```
/messages/compose
/messages/:messageId
```

If the first matched middleware is final (does not call `next()`) - there is no need to call the param for `:messageId`. And then its safe to `ctx.throw` or to do the auth logic inside the param middleware without breaking the first route.

I'm not sure about the correctness of the patch itself, but it doesn't break any existing tests.
